### PR TITLE
Fix release commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check-main": "branch=$(git rev-parse --abbrev-ref HEAD) && [ $branch = main ] || (echo 'Error: New release can only be published on main branch' && exit 1)",
     "lint": "eslint . && prettier --list-different packages/**/*.{js,json}",
     "prettier:write": "prettier --write packages/**/*.{js,json}",
-    "pub": "yarn publish --new-verion $npm_package_version --tag latest",
+    "pub": "npm publish --tag latest",
     "push": "git push --atomic origin main v$npm_package_version",
     "release:major": "yarn check-main && yarn version --major && yarn pub && yarn push",
     "release:minor": "yarn check-main && yarn version --minor && yarn pub && yarn push",


### PR DESCRIPTION
`yarn publish` was oddly inflexible - there's no option to use the current version in `package.json` and also no `--dry-run` flag for testing. Since `npm publish` doesn't interfere with `yarn.lock` it's safe to use in conjunction with yarn and makes our release commands much easier to use.