### PR TITLE
Fix detection of root fields.js in Windows

### DIFF
--- a/lib/handleFieldsJs.js
+++ b/lib/handleFieldsJs.js
@@ -164,7 +164,7 @@ function isConvertableFieldJs(rootDir, filePath, convertFields = false) {
   return !!(
     convertFields &&
     allowedFieldsNames.includes(baseName) &&
-    (inModuleFolder || relativePath == '/')
+    (inModuleFolder || relativePath == '/' || relativePath == '\\')
   );
 }
 


### PR DESCRIPTION
In Windows, the CLI doesn't properly detect a fields.js/mjs/cjs in the root of the theme, due to how the relativePath is checked. In Windows, it should check for `\`, instead of `/`. This is just a quick fix to make it check for both versions. There's probably a more "proper" way to get the root directory, but this works well enough on my system.