### PR TITLE
Allow custom extensions

### DIFF
--- a/path.js
+++ b/path.js
@@ -96,13 +96,13 @@ function getExt(filepath) {
   return ext[0] === '.' ? ext.slice(1) : ext;
 }
 
-const getAllowedExtensions = () => {
-  return ALLOWED_EXTENSIONS;
+const getAllowedExtensions = (allowList = []) => {
+  return new Set([...Array.from(ALLOWED_EXTENSIONS), ...allowList]);
 };
 
-const isAllowedExtension = filepath => {
+const isAllowedExtension = (filepath, allowList = []) => {
   const ext = getExt(filepath);
-  const allowedExtensions = getAllowedExtensions();
+  const allowedExtensions = getAllowedExtensions(allowList);
   return allowedExtensions.has(ext);
 };
 


### PR DESCRIPTION
Updating the allowed extensions utils to support passing in custom extensions. This lets us upload things like `.tsx` files from some of the developer projects commands.

@camden11 should I make this same change in local dev lib?