### PR TITLE
Add error handling for GitHub downloads

### DIFF
--- a/github.js
+++ b/github.js
@@ -231,13 +231,13 @@ async function downloadGitHubRepoContents(
     }
   } catch (e) {
     if (e.statusCode === 404) {
-      if (e.error.message) {
+      if (e.error && e.error.message) {
         throw new Error(`Failed to fetch contents: ${e.error.message}`);
       }
     }
 
     if (e.statusCode >= 500 && e.statusCode <= 599) {
-      if (e.error.message) {
+      if (e.error && e.error.message) {
         throw new Error(`Failed to fetch contents: ${e.error.message}`);
       } else {
         throw new Error('Failed to fetch contents: Check the status of GitHub');

--- a/github.js
+++ b/github.js
@@ -236,6 +236,14 @@ async function downloadGitHubRepoContents(
       }
     }
 
+    if (e.statusCode >= 500 && e.statusCode <= 599) {
+      if (e.error.message) {
+        throw new Error(`Failed to fetch contents: ${e.error.message}`);
+      } else {
+        throw new Error('Failed to fetch contents: Check the status of GitHub');
+      }
+    }
+
     throw new Error(e);
   }
 }


### PR DESCRIPTION
## Description and Context

Commands like `hs project create` download file contents from GitHub. If GitHub servers are down, then we receive a `503` error code, which we currently don't handle. I've added error handling for all commands that download content from GitHub. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before: 

<img width="2106" alt="Screenshot 2023-07-10 at 1 11 42 PM" src="https://github.com/HubSpot/cli-lib/assets/25392256/080ed62e-9c3a-4b3a-ad59-9ceb0f964cf4">

With these changes:

<img width="1915" alt="Screenshot 2023-07-10 at 1 12 18 PM" src="https://github.com/HubSpot/cli-lib/assets/25392256/25125943-132f-446a-bafa-10d15ceaa132">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

@brandenrodgers, @markhazlewood, could I receive some feedback on the copy here? `Failed to fetch contents: Check the status of GitHub` is a placeholder for now. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers  @markhazlewood 