### PR TITLE
Change repo and homepage links in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Library for creating scripts for working with HubSpot",
   "license": "Apache-2.0",
   "main": "index.js",
+  "homepage": "https://github.com/HubSpot/cli-lib#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/HubSpot/hubspot-cms-tools"
+    "url": "https://github.com/HubSpot/cli-lib"
   },
   "scripts": {
     "check-main": "branch=$(git rev-parse --abbrev-ref HEAD) && [ $branch = main ] || (echo 'Error: New release can only be published on main branch' && exit 1)",


### PR DESCRIPTION
## Description and Context
On the [npm page](https://www.npmjs.com/package/@hubspot/cli-lib) for the `cli-lib` package, the links to the GitHub repository and homepage are both incorrect. This PR edits the package.json to point to the correct urls. 

Based on information from this [Stack Overflow](https://stackoverflow.com/questions/48378842/how-to-add-link-of-my-github-repo-to-npm-package) and these [npm docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#homepage). 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@jsines @brandenrodgers 