### PR TITLE
HubSpotAuthError contains detailed error info, updated usage

### DIFF
--- a/lib/models/Errors.js
+++ b/lib/models/Errors.js
@@ -1,4 +1,14 @@
-class HubSpotAuthError extends Error {}
+class HubSpotAuthError extends Error {
+  constructor(message, errorResponse = {}) {
+    super(message);
+    this.name = 'HubSpotAuthError';
+    this.statusCode = errorResponse.statusCode;
+    this.category =
+      (errorResponse.body && errorResponse.body.category) || undefined;
+    this.subCategory =
+      (errorResponse.body && errorResponse.body.subCategory) || undefined;
+  }
+}
 
 module.exports = {
   HubSpotAuthError,

--- a/lib/models/OAuth2Manager.js
+++ b/lib/models/OAuth2Manager.js
@@ -100,7 +100,8 @@ class OAuth2Manager {
     } catch (e) {
       if (e.response) {
         throw new HubSpotAuthError(
-          `Error while retrieving new token: ${e.response.body.message}`
+          `Error while retrieving new token: ${e.response.body.message}`,
+          e.response
         );
       } else {
         throw e;

--- a/personalAccessKey.js
+++ b/personalAccessKey.js
@@ -33,15 +33,7 @@ async function getAccessToken(
   } catch (e) {
     if (e.response) {
       const errorOutput = `Error while retrieving new access token: ${e.response.body.message}.`;
-      if (e.response.statusCode === 401) {
-        // Before adjusting the error message below, please verify that changes do not break regex match in cli/commands/sandbox/delete.js
-        // For future changes: if response.statusCode is passed into the new error below, sandboxes can skip the regex check and pull the statusCode instead
-        throw new HubSpotAuthError(
-          `${errorOutput} \nYour personal access key is invalid. Please run "hs auth personalaccesskey" to reauthenticate. See https://designers.hubspot.com/docs/personal-access-keys for more information.`
-        );
-      } else {
-        throw new HubSpotAuthError(errorOutput);
-      }
+      throw new HubSpotAuthError(errorOutput, e.response);
     } else {
       throw e;
     }


### PR DESCRIPTION
This PR adds some additional info to the `HubSpotAuthError` class, and removes an additional message for 401 statusCode errors that may be inaccurate. 

Updated all usage of `HubSpotAuthError` to pass in `error.response` to have access to statusCode, category, and subCategory if available. 

Slack reference: https://hubspot.slack.com/archives/C01GV708YH3/p1689712056051499
