### PR TITLE
Account for project errors (other half in hubspot-cli)

### DIFF
--- a/errorHandlers/apiErrors.js
+++ b/errorHandlers/apiErrors.js
@@ -29,6 +29,9 @@ const isMissingScopeError = err =>
   err.error &&
   err.error.category === 'MISSING_SCOPES';
 
+const isGatingError = err =>
+  err.statusCode === 403 && err.error && err.error.category === 'GATED';
+
 const isSpecifiedError = (err, { statusCode, category, subCategory } = {}) => {
   const statusCodeErr = !statusCode || err.statusCode === statusCode;
   const categoryErr =
@@ -151,6 +154,7 @@ function logApiStatusCodeError(error, context) {
     errorMessage.push(`Unable to upload "${context.payload}".`);
   }
   const isProjectMissingScopeError = isMissingScopeError(error) && projectName;
+  const isProjectGatingError = isGatingError(error) && projectName;
   switch (statusCode) {
     case 400:
       errorMessage.push(`The ${messageDetail} was bad.`);
@@ -162,6 +166,10 @@ function logApiStatusCodeError(error, context) {
       if (isProjectMissingScopeError) {
         errorMessage.push(
           `Couldn\'t run the project command because there are scopes missing in your production account. To update scopes, deactivate your current personal access key for ${context.accountId}, and generate a new one. Then run \`hs auth\` to update the CLI with the new key.`
+        );
+      } else if (isProjectGatingError) {
+        errorMessage.push(
+          `Your production account ${context.accountId} does not have access to HubSpot projects. To opt in to the CRM Development Beta and use projects, visit https://app.hubspot.com/whats-new/40852147/betas?productUpdateId=13860216.`
         );
       } else {
         errorMessage.push(`The ${messageDetail} was forbidden.`);
@@ -198,7 +206,12 @@ function logApiStatusCodeError(error, context) {
       }
       break;
   }
-  if (error.error && error.error.message && !isProjectMissingScopeError) {
+  if (
+    error.error &&
+    error.error.message &&
+    !isProjectMissingScopeError &&
+    !isProjectGatingError
+  ) {
     errorMessage.push(error.error.message);
   }
   if (error.error && error.error.errors) {

--- a/errorHandlers/apiErrors.js
+++ b/errorHandlers/apiErrors.js
@@ -169,7 +169,7 @@ function logApiStatusCodeError(error, context) {
         );
       } else if (isProjectGatingError) {
         errorMessage.push(
-          `Your production account ${context.accountId} does not have access to HubSpot projects. To opt in to the CRM Development Beta and use projects, visit https://app.hubspot.com/whats-new/40852147/betas?productUpdateId=13860216.`
+          `The current target account ${context.accountId} does not have access to HubSpot projects. To opt in to the CRM Development Beta and use projects, visit https://app.hubspot.com/l/whats-new/betas?productUpdateId=13860216.`
         );
       } else {
         errorMessage.push(`The ${messageDetail} was forbidden.`);

--- a/errorHandlers/apiErrors.js
+++ b/errorHandlers/apiErrors.js
@@ -30,7 +30,7 @@ const isMissingScopeError = err =>
   err.error.category === 'MISSING_SCOPES';
 
 const isGatingError = err =>
-  err.statusCode === 403 && err.error && err.error.category === 'GATED';
+  isSpecifiedError(err, { statusCode: 403, category: 'GATED' });
 
 const isSpecifiedError = (err, { statusCode, category, subCategory } = {}) => {
   const statusCodeErr = !statusCode || err.statusCode === statusCode;


### PR DESCRIPTION
## Description and Context
Because projects are officially in public beta, we're unhiding project commands in the hubspot-cli. As part of that effort, I'm also providing more detailed error messages for certain scenarios. 

In this PR, so far, I've added handling for gating errors with project commands. I may also add handling for downgrading errors.

The [other half](https://github.com/HubSpot/hubspot-cli/pull/893) of this PR is located in the hubspot-cli repo. Go to that PR for instructions for testing.

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Possibly add handling for downgrading errors (not necessary). 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 