### PR TITLE
Remove extra period for PAK error message

### DIFF
--- a/personalAccessKey.js
+++ b/personalAccessKey.js
@@ -32,7 +32,7 @@ async function getAccessToken(
     response = await fetchAccessToken(personalAccessKey, env, accountId);
   } catch (e) {
     if (e.response) {
-      const errorOutput = `Error while retrieving new access token: ${e.response.body.message}.`;
+      const errorOutput = `Error while retrieving new access token: ${e.response.body.message}`;
       throw new HubSpotAuthError(errorOutput, e.response);
     } else {
       throw e;


### PR DESCRIPTION
Very minor change - error messages returned from localdevauth already include a period at the end. This PR just removes the extra period from the message builder

Screenshots:

Before:

<img width="1255" alt="Screenshot 2023-07-26 at 12 02 12" src="https://github.com/HubSpot/cli-lib/assets/16788677/c121a345-d01f-4c78-86bd-535f00d9e45f">
<img width="873" alt="Screenshot 2023-07-26 at 12 04 13" src="https://github.com/HubSpot/cli-lib/assets/16788677/fe5ab748-169e-4081-a8a9-6eb9841c64bb">


After:

<img width="913" alt="Screenshot 2023-07-26 at 12 04 24" src="https://github.com/HubSpot/cli-lib/assets/16788677/1c1220f5-ce33-491a-acca-23b7d0b0c595">
<img width="1260" alt="Screenshot 2023-07-26 at 12 04 45" src="https://github.com/HubSpot/cli-lib/assets/16788677/f48c811f-9683-4028-847c-7021f362b233">
