### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description and Context
+<!-- Provide a summary of what has changed -->
+<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
+<!-- Describe any packages you'd like to add and the reasons why. -->
+
+## Screenshots
+<!-- Provide images of the before and after functionality -->
+
+## TODO
+<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
+
+## Who to Notify
+<!-- /cc those you wish to know about the PR -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,8 @@
 
 ## TODO
 <!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
+<!--IMPORTANT: When making any changes to cli-lib, check to see if the files you've changed have already been ported to hubspot-local-dev-lib. If they have, please make a PR to hubspot-local-dev-lib with your changes. New files should also be ported to hubspot-local-dev-lib if all of their dependancies have already been ported -->
+- [] Port these changes to [hubspot-local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib)
 
 ## Who to Notify
 <!-- /cc those you wish to know about the PR -->


### PR DESCRIPTION
This adds the PR template from `hubspot-cli` to this repo, and includes a reminder to port changes to `hubspot-local-dev-lib`