### PR TITLE
Refactor project download endpoint (Other half in hubspot-cli)

### DIFF
--- a/api/dfs.js
+++ b/api/dfs.js
@@ -88,21 +88,11 @@ async function fetchProject(accountId, projectName) {
  * @param {string} projectName
  * @returns {Promise}
  */
-async function downloadProject(
-  accountId,
-  projectName,
-  buildId,
-  platformVersion
-) {
-  const requestString = platformVersion
-    ? `${PROJECTS_API_PATH}/${encodeURIComponent(
-        projectName
-      )}/builds/${buildId}/archive-full?platformVersion=${platformVersion}`
-    : `${PROJECTS_API_PATH}/${encodeURIComponent(
-        projectName
-      )}/builds/${buildId}/archive-full`;
+async function downloadProject(accountId, projectName, buildId) {
   return http.get(accountId, {
-    uri: requestString,
+    uri: `${PROJECTS_API_PATH}/${encodeURIComponent(
+      projectName
+    )}/builds/${buildId}/archive-full`,
     encoding: null,
     headers: { accept: 'application/zip', contentType: 'application/json' },
   });

--- a/api/dfs.js
+++ b/api/dfs.js
@@ -88,13 +88,13 @@ async function fetchProject(accountId, projectName) {
  * @param {string} projectName
  * @returns {Promise}
  */
-async function downloadProject(accountId, projectName, buildId) {
+async function downloadProject(accountId, projectName, buildId = 1) {
   return http.get(accountId, {
     uri: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
-    )}/builds/${buildId}/archive`,
+    )}/builds/${buildId}/archive-full`,
     encoding: null,
-    headers: { accept: 'application/octet-stream' },
+    headers: { accept: 'application/zip', contentType: 'application/json' },
   });
 }
 

--- a/api/dfs.js
+++ b/api/dfs.js
@@ -88,11 +88,21 @@ async function fetchProject(accountId, projectName) {
  * @param {string} projectName
  * @returns {Promise}
  */
-async function downloadProject(accountId, projectName, buildId = 1) {
+async function downloadProject(
+  accountId,
+  projectName,
+  buildId,
+  platformVersion
+) {
+  const requestString = platformVersion
+    ? `${PROJECTS_API_PATH}/${encodeURIComponent(
+        projectName
+      )}/builds/${buildId}/archive-full?platformVersion=${platformVersion}`
+    : `${PROJECTS_API_PATH}/${encodeURIComponent(
+        projectName
+      )}/builds/${buildId}/archive-full`;
   return http.get(accountId, {
-    uri: `${PROJECTS_API_PATH}/${encodeURIComponent(
-      projectName
-    )}/builds/${buildId}/archive-full`,
+    uri: requestString,
     encoding: null,
     headers: { accept: 'application/zip', contentType: 'application/json' },
   });


### PR DESCRIPTION
## Description and Context
I'm refactoring the project download command to use a different download endpoint (`/archive-full`) that downloads the project's `src` folder and `hsproject.json`. 

See the other half of this work in the [hubspot-cli PR](https://github.com/HubSpot/hubspot-cli/pull/907). Instructions on testing will be provided there. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
