### PR TITLE
Util for specified auth errors

### DIFF
--- a/errorHandlers/apiErrors.js
+++ b/errorHandlers/apiErrors.js
@@ -44,6 +44,21 @@ const isSpecifiedError = (err, { statusCode, category, subCategory } = {}) => {
   );
 };
 
+const isSpecifiedHubSpotAuthError = (
+  err,
+  { statusCode, category, subCategory }
+) => {
+  const statusCodeErr = !statusCode || err.statusCode === statusCode;
+  const categoryErr = !category || err.category === category;
+  const subCategoryErr = !subCategory || err.subCategory === subCategory;
+  return (
+    err.name === 'HubSpotAuthError' &&
+    statusCodeErr &&
+    categoryErr &&
+    subCategoryErr
+  );
+};
+
 const contactSupportString =
   'Please try again or visit https://help.hubspot.com/ to submit a ticket or contact HubSpot Support if the issue persists.';
 
@@ -309,4 +324,5 @@ module.exports = {
   logServerlessFunctionApiErrorInstance,
   isMissingScopeError,
   isSpecifiedError,
+  isSpecifiedHubSpotAuthError,
 };


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

`isSpecifiedError` only supports errors with name `StatusCodeError`. This PR adds a util for checking specific `HubSpotAuthError` instances

Usage of this util here: https://github.com/HubSpot/hubspot-cli/pull/899/files

## Screenshots
<!-- Provide images of the before and after functionality -->
n/a

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
<!--IMPORTANT: When making any changes to cli-lib, check to see if the files you've changed have already been ported to hubspot-local-dev-lib. If they have, please make a PR to hubspot-local-dev-lib with your changes. New files should also be ported to hubspot-local-dev-lib if all of their dependancies have already been ported -->
- [ ] Port these changes to [hubspot-local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib)

^^ I couldn't find a direct map for `isSpecifiedError`, the closest thing was [throwError](https://github.com/HubSpot/hubspot-local-dev-lib/blob/main/errors/standardErrors.ts#L70-L84) and [throwStatusCodeError](https://github.com/HubSpot/hubspot-local-dev-lib/blob/main/errors/apiErrors.ts) but they seem to support errors not named `StatusCodeError`

## Who to Notify
<!-- /cc those you wish to know about the PR -->
