### PR TITLE
Refactor GitHub utils to accept a branch or tag

### DIFF
--- a/github.js
+++ b/github.js
@@ -15,8 +15,6 @@ const GITHUB_AUTH_HEADERS = {
     global && global.githubToken ? `Bearer ${global.githubToken}` : null,
 };
 
-const getRefQuery = ref => (ref ? `?ref=${ref}` : '');
-
 /**
  * @param {String} filePath - path where config file is stored
  * @param {String} repoName - name of the github repository
@@ -142,9 +140,8 @@ async function cloneGitHubRepo(dest, type, repoName, sourceDir, options = {}) {
 }
 
 async function getGitHubRepoContentsAtPath(repoPath, path, ref) {
-  const contentsRequestUrl = `https://api.github.com/repos/${repoPath}/contents/${path}${getRefQuery(
-    ref
-  )}`;
+  const refQuery = ref ? `?ref=${ref}` : '';
+  const contentsRequestUrl = `https://api.github.com/repos/${repoPath}/contents/${path}${refQuery}`;
 
   return request.get(contentsRequestUrl, {
     json: true,

--- a/github.js
+++ b/github.js
@@ -207,7 +207,8 @@ async function downloadGitHubRepoContents(
       if (contentPieceType === 'dir') {
         const innerDirContent = await getGitHubRepoContentsAtPath(
           repoName,
-          contentPiecePath
+          contentPiecePath,
+          options.ref
         );
         return Promise.all(innerDirContent.map(downloadContentRecursively));
       } else {

--- a/github.js
+++ b/github.js
@@ -61,9 +61,10 @@ async function fetchReleaseData(repoName, tag = '') {
     tag = `v${tag}`;
   }
   const URI = tag
-    ? `https://api.github.com/repos/HubSpot/${repoName}/releases/tags/${tag}`
-    : `https://api.github.com/repos/HubSpot/${repoName}/releases/latest`;
+    ? `https://api.github.com/repos/${repoName}/releases/tags/${tag}`
+    : `https://api.github.com/repos/${repoName}/releases/latest`;
   try {
+    console.log(URI);
     return await request.get(URI, {
       headers: { ...DEFAULT_USER_AGENT_HEADERS, ...GITHUB_AUTH_HEADERS },
       json: true,
@@ -95,7 +96,7 @@ async function downloadGithubRepoZip(
     let zipUrl;
     if (releaseType === GITHUB_RELEASE_TYPES.REPOSITORY) {
       logger.log(`Fetching ${releaseType} with name ${repoName}...`);
-      zipUrl = `https://api.github.com/repos/HubSpot/${repoName}/zipball${
+      zipUrl = `https://api.github.com/repos/${repoName}/zipball${
         ref ? `/${ref}` : ''
       }`;
     } else {
@@ -255,4 +256,5 @@ module.exports = {
   cloneGitHubRepo,
   downloadGitHubRepoContents,
   fetchJsonFromRepository,
+  fetchReleaseData,
 };

--- a/github.js
+++ b/github.js
@@ -64,7 +64,6 @@ async function fetchReleaseData(repoName, tag = '') {
     ? `https://api.github.com/repos/${repoName}/releases/tags/${tag}`
     : `https://api.github.com/repos/${repoName}/releases/latest`;
   try {
-    console.log(URI);
     return await request.get(URI, {
       headers: { ...DEFAULT_USER_AGENT_HEADERS, ...GITHUB_AUTH_HEADERS },
       json: true,


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/449 and https://github.com/HubSpot/hubspot-cli/pull/927
We want to be able to fetch templates from a specific tag in `hubspot-project-components` when running `hs project create`, but our github utils currently do not support that in a straightforward way. This updates the necessary functions to accept an optional `ref`, and makes a few changes to improve readability. This slightly changes the API of some of the github functions, so may need to be a major release.

Keeping this as a draft for now since I still need to test everything

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
<!--IMPORTANT: When making any changes to cli-lib, check to see if the files you've changed have already been ported to hubspot-local-dev-lib. If they have, please make a PR to hubspot-local-dev-lib with your changes. New files should also be ported to hubspot-local-dev-lib if all of their dependancies have already been ported -->
- [x] Port these changes to [hubspot-local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib) [(issue)](https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/451)

## Who to Notify
@brandenrodgers 
