### PR TITLE
Allow deprecated module warnings through validation

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -32,6 +32,7 @@ async function lint(accountId, filepath, callback) {
           return result;
         }
         const validation = await validateHubl(accountId, source);
+
         const result = {
           file,
           validation,
@@ -59,15 +60,13 @@ function printHublValidationResult({ file, validation }) {
   if (!errors.length) {
     return count;
   }
-  logger.group(file);
   errors.forEach(err => {
-    if (err.reason !== 'SYNTAX_ERROR') {
+    if (err.reason !== 'SYNTAX_ERROR' && err.category !== 'DEPRECATED_MODULE') {
       return;
     }
     ++count;
     printHublValidationError(err);
   });
-  logger.groupEnd(file);
   return count;
 }
 


### PR DESCRIPTION
## Description and Context
In conjunction with https://github.com/HubSpot/hubspot-cli/pull/931

- Removing logger grouping from output (to clean it up)
- Adding `DEPRECATED_MODULE` category to allowed output

## TODO
- [ ] As mentioned in https://github.com/HubSpot/hubspot-cli/pull/931 - Determine warnings/errors that should come through the `lint` command -- might be good to refactor the conditional here and look through a list of constants/an allowlist for this
- [ ] Port these changes to [hubspot-local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib)