### PR TITLE
Resource proxying

### DIFF
--- a/lib/preview/createRoutes.js
+++ b/lib/preview/createRoutes.js
@@ -6,13 +6,24 @@ const { buildModuleRouteHandler } = require('./routes/module.js');
 const { buildTemplateRouteHandler } = require('./routes/template.js');
 const { buildMetaRouteHandler } = require('./routes/meta.js');
 
+const { proxyResourceRedirectHandler } = require('./routes/proxyResourceRedirect.js');
+
 const createPreviewServerRoutes = async (sessionInfo) => {
     const previewServerRouter = Router();
-    previewServerRouter.get('/', buildIndexRouteHandler(sessionInfo));
     previewServerRouter.get('/proxy', buildProxyRouteHandler(sessionInfo));
     previewServerRouter.get('/module/:name', buildModuleRouteHandler(sessionInfo));
     previewServerRouter.get('/template/:name', buildTemplateRouteHandler(sessionInfo));
     previewServerRouter.get('/meta', buildMetaRouteHandler(sessionInfo));
+
+    previewServerRouter.get('/*', proxyResourceRedirectHandler);
+    previewServerRouter.post('/*', proxyResourceRedirectHandler);
+    previewServerRouter.delete('/*', proxyResourceRedirectHandler);
+    previewServerRouter.head('/*', proxyResourceRedirectHandler);
+    previewServerRouter.put('/*', proxyResourceRedirectHandler);
+    previewServerRouter.options('/*', proxyResourceRedirectHandler);
+
+    previewServerRouter.get('/', buildIndexRouteHandler(sessionInfo));
+
     return previewServerRouter;
 }
 

--- a/lib/preview/routes/proxyResourceRedirect.js
+++ b/lib/preview/routes/proxyResourceRedirect.js
@@ -1,0 +1,49 @@
+const fetch = require('node-fetch-commonjs');
+
+const HCMS_PATH = '/_hcms/';
+const HS_FS_PATH = '/hs-fs/'
+const HUB_FS_PATH = '/hubfs/';
+
+const isInternalCMSRoute = (req) =>
+  req.path.startsWith(HCMS_PATH) ||
+  req.path.startsWith(HS_FS_PATH) ||
+  req.path.startsWith(HUB_FS_PATH);
+
+const proxyResourceRedirectHandler = (req, res, next) => {
+  const isAHtmlRequest = req.accepts().includes('text/html');
+
+  // proxy when referer's path is /proxy and has page query param
+  let proxyPageUrl;
+  let refererUrl;
+  try {
+    refererUrl = new URL(req.headers.referer);
+    proxyPageUrl = new URL(
+      new URL(req.headers.referer).searchParams.get('page')
+    );
+  } catch (e) {
+    next();
+    return;
+  }
+  if (!refererUrl.pathname.startsWith('/proxy')) {
+    next();
+    return;
+  }
+
+  // handle anchor links unless internal CMS route
+  if (isAHtmlRequest && !isInternalCMSRoute(req)) {
+    const encodedPageUrl = encodeURIComponent(
+      `${proxyPageUrl.origin}${req.url}`
+    );
+    res.redirect(`/proxy?page=${encodedPageUrl}`);
+    return;
+  }
+
+  const urlToProxy = `https://${proxyPageUrl.host}${req.url}`;
+  fetch(urlToProxy)
+    .then(response => response.body.pipe(res)) // https://github.com/node-fetch/node-fetch#bodybody
+    .catch(err => console.log(`crying on ${err}`));
+}
+
+module.exports = {
+  proxyResourceRedirectHandler,
+}

--- a/lib/preview/routes/proxyResourceRedirect.js
+++ b/lib/preview/routes/proxyResourceRedirect.js
@@ -41,7 +41,7 @@ const proxyResourceRedirectHandler = (req, res, next) => {
   const urlToProxy = `https://${proxyPageUrl.host}${req.url}`;
   fetch(urlToProxy)
     .then(response => response.body.pipe(res)) // https://github.com/node-fetch/node-fetch#bodybody
-    .catch(err => console.log(`crying on ${err}`));
+    .catch(err => console.error(err));
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jest": "^26.6.3",
     "js-yaml": "^4.1.0",
     "moment": "^2.24.0",
+    "node-fetch-commonjs": "^3.3.2",
     "p-queue": "^6.0.2",
     "prettier": "^1.19.1",
     "request": "^2.87.0",


### PR DESCRIPTION
## Description and Context
Since resources can be fetched from the domain of the page in the browser, so when a proxied page tries to fetch a resource `/resource.js` it tries to fetch from `localhost:3000/resource.js` instead of the domain where it's actually located. Likewise for redirects - if the user is on `localhost:3000/proxy?page=https://www.example.com`, and clicks a link on the page that would otherwise link them to `https://www.example.com/test`, it will instead send them to `localhost:3000/text`, when we really want to send them to `localhost:3000/proxy?page=https://www.example.com/test` 

Seeing the effect of this should be simple - load a proxied page with and without this change and see the 404's in the browser console disappear! 
