### PR TITLE
@preview folder support, module/template proxying/auto-refreshing

### DIFF
--- a/lib/preview.js
+++ b/lib/preview.js
@@ -2,6 +2,7 @@ const http = require('http');
 const path = require('path');
 const chokidar = require('chokidar');
 const express = require('express');
+const { v4: uuidv4 } = require('uuid');
 const { logger } = require('../logger');
 const {
   ApiErrorContext,
@@ -175,9 +176,10 @@ const preview = async (
 ) => {
   const accountConfig = getAccountConfig(accountId);
   const domains = await getPortalDomains(accountId);
+  const sessionToken = uuidv4();
   const sessionInfo = {
     src,
-    dest,
+    dest: `@preview/${sessionToken}/${dest}`,
     portalName: accountConfig.name,
     portalId: accountId,
     env: accountConfig.env,
@@ -185,7 +187,7 @@ const preview = async (
     // we find hublet later in the content metadata fetch
     // can we get that ahead of time? hardcoding it for now
     hublet: 'na1',
-    sessionToken: Date.now(),
+    sessionToken,
     domains,
   }
 

--- a/lib/preview/createRoutes.js
+++ b/lib/preview/createRoutes.js
@@ -11,8 +11,8 @@ const { proxyResourceRedirectHandler } = require('./routes/proxyResourceRedirect
 const createPreviewServerRoutes = async (sessionInfo) => {
     const previewServerRouter = Router();
     previewServerRouter.get('/proxy', buildProxyRouteHandler(sessionInfo));
-    previewServerRouter.get('/module/:name', buildModuleRouteHandler(sessionInfo));
-    previewServerRouter.get('/template/:name', buildTemplateRouteHandler(sessionInfo));
+    previewServerRouter.get('/module/:modulePath', buildModuleRouteHandler(sessionInfo));
+    previewServerRouter.get('/template/:templatePath', buildTemplateRouteHandler(sessionInfo));
     previewServerRouter.get('/meta', buildMetaRouteHandler(sessionInfo));
 
     previewServerRouter.get('/*', proxyResourceRedirectHandler);

--- a/lib/preview/previewUtils.js
+++ b/lib/preview/previewUtils.js
@@ -52,7 +52,7 @@ const addRefreshScript = (html) => {
   const refreshScript = `
   <script>
   setInterval(() => {
-    const res = fetch('/meta')
+    const res = fetch('http://localhost:3000/meta')
       .then(async (res) => {
         const hsServerState = await res.json();
         if (hsServerState["REMOTE_FS_IS_DIRTY"]) {

--- a/lib/preview/routes/module.js
+++ b/lib/preview/routes/module.js
@@ -1,34 +1,38 @@
-const http = require('http')
+const http = require('../../../http')
 const { fetchModulesByPath, fetchModuleBuffer } = require('../../../api/designManager');
 const { getPreviewUrl } = require('../previewUtils');
+const { addRefreshScript } = require('../previewUtils');
 
 
 const buildModuleRouteHandler = (sessionInfo) => {
   const { portalId } = sessionInfo;
 
   return async (req, res) => {
-    const { name } = req.params;
-    if (!name) {
+    const { modulePath } = req.params;
+    if (!modulePath) {
       res.status(200).set({ 'Content-Type': 'text/html' }).end(buildModuleIndex());
       return;
     }
-    const customWidgetInfo = await fetchModulesByPath(portalId, `${sessionInfo.dest}/modules/${name}.module`);
+    const customWidgetInfo = await fetchModulesByPath(portalId, `${sessionInfo.dest}/modules/${modulePath}.module`);
     if (!('moduleId' in customWidgetInfo && 'previewKey' in customWidgetInfo)) {
       res.status(200).set({ 'Content-Type': 'text/html' }).end(buildErrorIndex());
       return;
     }
     const params = {
       module_id: customWidgetInfo.moduleId,
-      //is_buffered: true,
-      //portalId: portalId,
-      //language: 'en',
       hs_preview_key: customWidgetInfo.previewKey,
-      //hsPreviewerApp: 'module',
-      //updated:
+      ...req.query
     }
-    const previewUrl = getPreviewUrl(sessionInfo, params);
-    console.log(previewUrl)
-    res.redirect(previewUrl);
+    const previewUrl = new URL(getPreviewUrl(sessionInfo, params))  ;
+    const result = await http.get(portalId, {
+      baseUrl: previewUrl.origin,
+      uri: previewUrl.pathname,
+      query: params,
+      json: false,
+      useQuerystring: true,
+    });
+    const html = addRefreshScript(result)
+    res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
   }
 }
 

--- a/lib/preview/routes/template.js
+++ b/lib/preview/routes/template.js
@@ -1,19 +1,19 @@
-const http = require('http')
+const http = require('../../../http');
 const { fetchTemplatesByPath } = require('../../../api/designManager');
 const { getPreviewUrl } = require('../previewUtils');
+const { addRefreshScript } = require('../previewUtils');
 
 
 const buildTemplateRouteHandler = (sessionInfo) => {
   const { portalId } = sessionInfo;
 
   return async (req, res) => {
-    const { name } = req.params;
-    if (!name) {
+    const { templatePath } = req.params;
+    if (!templatePath) {
       res.status(200).set({ 'Content-Type': 'text/html' }).end(buildTemplateIndex());
       return;
     }
-
-    const calculatedPath = `${sessionInfo.dest}/templates/${name}`;
+    const calculatedPath = `${sessionInfo.dest}/templates/${templatePath}`;
     const templateInfo = await fetchTemplatesByPath(portalId, calculatedPath);
     if (!('previewKey' in templateInfo)) {
       res.status(502).set({ 'Content-Type': 'text/html' }).end(buildErrorIndex());
@@ -21,16 +21,19 @@ const buildTemplateRouteHandler = (sessionInfo) => {
     }
     const params = {
       template_file_path: calculatedPath,
-      //is_buffered: true,
-      //portalId: portalId,
-      //language: 'en',
       hs_preview_key: templateInfo.previewKey,
-      //hsPreviewerApp: 'module',
-      //updated
+      ...req.query
     }
-    const previewUrl = getPreviewUrl(sessionInfo, params);
-    console.log(previewUrl)
-    res.redirect(previewUrl);
+    const previewUrl = new URL(getPreviewUrl(sessionInfo, params));
+    const result = await http.get(portalId, {
+      baseUrl: previewUrl.origin,
+      uri: previewUrl.pathname,
+      query: params,
+      json: false,
+      useQuerystring: true,
+    });
+    const html = addRefreshScript(result)
+    res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
   }
 }
 


### PR DESCRIPTION
## Description and Context
Moves sessionToken to a UUID, splice preview folder stuff into `dest`, moves module and template back to proxying instead of redirect (which happens to work now I believe because of resource proxying stuff from last week). Adds autorefreshing for those as well! 

`@preview` folder requires the [Cms:LocalHublPreviews](https://tools.hubteamqa.com/gates/gates/Cms%3ALocalHublPreviews/hubs) gate. Looking into how we can add a check for this