### PR TITLE
Make local-dev-lib a peerdependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "0.0.7",
     "chalk": "^2.4.2",
     "chokidar": "^3.0.1",
     "content-disposition": "^0.5.3",
@@ -43,7 +42,11 @@
   },
   "devDependencies": {
     "lint-staged": "^10.5.4",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "@hubspot/local-dev-lib": "^0.0.8"
+  },
+  "peerDependencies": {
+    "@hubspot/local-dev-lib": "^0.0.8"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Context
Previously, both `hubspot-cli` and `cli-lib` used the `cli-lib/config` module to interact with the `hubspot.config.yml` file. The `config` module stores information about the config file in a global variable called `__config`. We recently introduced `hubspot-local-dev-lib` as a dependency to the CLI. Many modules within `local-dev-lib` also need to interact with config files, and as `local-dev-lib` is itself a port of `cli-lib`, it also provides its own config module with its own instance of `__config`. Having two separate instances of `__config` causes bugs, so in an attempt to remedy this, we added `local-dev-lib` as a dep to `cli-lib` and deferred to its instance of `__config`. Unfortunately things were not so simple. `hubspot-cli`'s dependancies on `hubspot-local-dev-lib` look something like this:

* `node_modules/@hubspot/local-dev-lib`
* `node_modules/@hubspot/clli-lib/node_modules/local-dev-lib`

This works, but _only_ if both `hubspot-cli` and `cli-lib` use the same version of `@hubspot-local-dev-lib`. There are many ways for versions between the two to get out of whack, resulting in two separate `__config` instances and causing bugs. Our solution is to switch `local-dev-lib` to a `peerDependency` within the CLI. Peer dependencies are a feature of npm that allow you to stipulate that package A requires package B, but will not install the dependency on its own. Instead, any package C that has a dependency on package A must also have a dependency on package B. By using them, we can assure that package A (cli-lib) uses the same package B (local-dev-lib) as package C (hubspot-cli).

The only side effect is that now, any package with a dependency on `cli-lib` must also explicitly specify a dependency on `local-dev-lib` in its `package.json`. We will have to do a major release to make this change

#### Some more info on `peerDependencies`, since we didn't know much about them prior to running into this problem
* https://nodejs.org/en/blog/npm/peer-dependencies
* https://www.youtube.com/watch?v=ZosDFmHW-CQ

## Who to Notify
@brandenrodgers 
