### PR TITLE
bump local dev lib peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "unixify": "1.0.0"
   },
   "devDependencies": {
-    "@hubspot/local-dev-lib": "^0.0.8",
+    "@hubspot/local-dev-lib": "^0.1.0",
     "lint-staged": "^10.5.4",
     "prettier": "^1.19.1"
   },
   "peerDependencies": {
-    "@hubspot/local-dev-lib": "^0.0.8"
+    "@hubspot/local-dev-lib": "^0.1.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
The version for local-dev-lib in the CLI was bumped to `0.1.0`. That no longer satisfies this peer dep (b/c local-dev-lib is still in pre-release so ^ only picks up patch updates) so we need to bump it.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
<!--IMPORTANT: When making any changes to cli-lib, check to see if the files you've changed have already been ported to hubspot-local-dev-lib. If they have, please make a PR to hubspot-local-dev-lib with your changes. New files should also be ported to hubspot-local-dev-lib if all of their dependancies have already been ported -->
- [] Port these changes to [hubspot-local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib)

## Who to Notify
<!-- /cc those you wish to know about the PR -->
