### PR TITLE
Add deprecation annotations to ported utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Deprecated
+
+This library is deprecated and is currently being replaced by the new [local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib) library. This library will remain available for use, but no new functionality will be added to it
+
 ## Table of Contents
 
 - [Overview](#what-is-cli-lib-for)

--- a/api/fileMapper.js
+++ b/api/fileMapper.js
@@ -169,6 +169,10 @@ async function deleteFolder(accountId, folderPath, options = {}) {
 }
 
 /**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib (@hubspot/local-dev-lib/trackUsage)
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ *
  * Track CMS CLI usage
  *
  * @async

--- a/archive.js
+++ b/archive.js
@@ -117,6 +117,11 @@ function cleanupTempDir(tmpDir) {
   }
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function extractZipArchive(
   zip,
   name,

--- a/ignoreRules.js
+++ b/ignoreRules.js
@@ -33,6 +33,12 @@ const ignoreRules = ignore().add(ignoreList);
 
 let searchDomain = null;
 let loaded = false;
+
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 function loadIgnoreConfig(isInProject = false) {
   if (loaded) {
     return;
@@ -54,6 +60,11 @@ function loadIgnoreConfig(isInProject = false) {
   loaded = true;
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 function shouldIgnoreFile(file, isInProject) {
   loadIgnoreConfig(isInProject);
   const relativeTo = searchDomain || '/';
@@ -62,11 +73,21 @@ function shouldIgnoreFile(file, isInProject) {
   return !!relativePath && ignoreRules.ignores(relativePath);
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 function createIgnoreFilter(isInProject) {
   loadIgnoreConfig(isInProject);
   return file => !shouldIgnoreFile(file);
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 function ignoreFile(filePath) {
   ignoreRules.add(filePath);
 }

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,6 +1,9 @@
 const { ENVIRONMENTS } = require('./constants');
 
 /**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
  * Returns environment constant for QA and PROD or optional masked value for PROD
  * @param {string} env Environment string, can be any case
  * @param {(boolean|object)} shouldMaskProduction Returning alternate value for PROD

--- a/lib/files.js
+++ b/lib/files.js
@@ -6,7 +6,7 @@ const { ENVIRONMENTS } = require('./constants');
 
 /**
  * @deprecated
- * Use the corresponding export from local-dev-lib
+ * Use the corresponding export from local-dev-lib (renamed to @hubspot/local-dev-lib/cms/themes)
  * https://github.com/HubSpot/hubspot-local-dev-lib
  */
 const getThemeJSONPath = path =>
@@ -23,6 +23,11 @@ const getThemeNameFromPath = filePath => {
   return pathParts[pathParts.length - 2];
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib (renamed to @hubspot/local-dev-lib/cms/themes)
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getThemePreviewUrl = (filePath, accountId) => {
   const themeName = getThemeNameFromPath(filePath);
   if (!themeName) return;

--- a/lib/files.js
+++ b/lib/files.js
@@ -4,6 +4,11 @@ const { getEnv } = require('@hubspot/local-dev-lib/config');
 const { getHubSpotWebsiteOrigin } = require('./urls');
 const { ENVIRONMENTS } = require('./constants');
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getThemeJSONPath = path =>
   findup('theme.json', {
     cwd: path,

--- a/lib/git.js
+++ b/lib/git.js
@@ -104,6 +104,11 @@ const checkAndWarnGitInclusion = configPath => {
   }
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib (renamed to @hubspot/local-dev-lib/gitignore)
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const checkAndUpdateGitignore = configPath => {
   try {
     const { configIgnored, gitignoreFiles } = checkGitInclusion(configPath);

--- a/lib/table.js
+++ b/lib/table.js
@@ -33,12 +33,22 @@ const tableConfigDefaults = {
   },
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getTableContents = (tableData = [], tableConfig = {}) => {
   const mergedConfig = mergeDeep({}, tableConfigDefaults, tableConfig);
 
   return table(tableData, mergedConfig);
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getTableHeader = headerItems => {
   return headerItems.map(headerItem => chalk.bold(headerItem));
 };

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,3 +1,8 @@
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const commaSeparatedValues = (arr, conjunction = 'and', ifempty = '') => {
   let l = arr.length;
   if (!l) return ifempty;

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -8,10 +8,20 @@ const getEnvUrlString = env => {
   return env.toLowerCase() === ENVIRONMENTS.QA ? ENVIRONMENTS.QA : '';
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getHubSpotWebsiteOrigin = env => {
   return `https://app.hubspot${getEnvUrlString(env)}.com`;
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getHubSpotApiOrigin = (env, useLocalHost) => {
   let domain = process.env.HUBAPI_DOMAIN_OVERRIDE;
 

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -28,6 +28,11 @@ const generateRecursiveFilePromise = async (dir, file) => {
   });
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function walk(dir) {
   const processFiles = files =>
     Promise.all(files.map(file => generateRecursiveFilePromise(dir, file)));

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -30,7 +30,7 @@ const generateRecursiveFilePromise = async (dir, file) => {
 
 /**
  * @deprecated
- * Use the corresponding export from local-dev-lib
+ * Use the corresponding export from local-dev-lib (@hubspot/local-dev-lib/fs)
  * https://github.com/HubSpot/hubspot-local-dev-lib
  */
 async function walk(dir) {

--- a/path.js
+++ b/path.js
@@ -2,16 +2,29 @@ const path = require('path');
 const unixify = require('unixify');
 const { ALLOWED_EXTENSIONS } = require('./lib/constants');
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const convertToUnixPath = _path => {
   return unixify(path.normalize(_path));
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const convertToWindowsPath = _path => {
   const rgx = new RegExp(`\\${path.posix.sep}`, 'g');
   return path.normalize(_path).replace(rgx, path.win32.sep);
 };
 
 /**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
  * Converts a Win32 path to Posix, retaining the drive letter (ex. 'c:')
  *
  * @param {string} _path
@@ -23,6 +36,11 @@ const convertToImportPath = _path => {
   return _path;
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const convertToLocalFileSystemPath = _path => {
   switch (path.sep) {
     case path.posix.sep:
@@ -45,6 +63,9 @@ const removeTrailingSlashFromSplits = parts => {
 };
 
 /**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
  * Splits a filepath for local file system sources.
  *
  * @param {string} filepath
@@ -64,6 +85,9 @@ const splitLocalPath = (filepath, pathImplementation = path) => {
 };
 
 /**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
  * Splits a filepath for remote sources (HubSpot).
  *
  * @param {string} filepath
@@ -80,6 +104,11 @@ const splitHubSpotPath = filepath => {
   return removeTrailingSlashFromSplits(parts);
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getCwd = () => {
   if (process.env.INIT_CWD) {
     return process.env.INIT_CWD;
@@ -87,6 +116,11 @@ const getCwd = () => {
   return process.cwd();
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 function getExt(filepath) {
   if (typeof filepath !== 'string') return '';
   const ext = path
@@ -96,18 +130,38 @@ function getExt(filepath) {
   return ext[0] === '.' ? ext.slice(1) : ext;
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getAllowedExtensions = (allowList = []) => {
   return new Set([...Array.from(ALLOWED_EXTENSIONS), ...allowList]);
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const isAllowedExtension = (filepath, allowList = []) => {
   const ext = getExt(filepath);
   const allowedExtensions = getAllowedExtensions(allowList);
   return allowedExtensions.has(ext);
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getAbsoluteFilePath = _path => path.resolve(getCwd(), _path);
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const isRelativePath = _path => !path.isAbsolute(_path);
 
 module.exports = {

--- a/personalAccessKey.js
+++ b/personalAccessKey.js
@@ -23,6 +23,11 @@ function getRefreshKey(personalAccessKey, expiration) {
   return `${personalAccessKey}-${expiration || 'fresh'}`;
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function getAccessToken(
   personalAccessKey,
   env = ENVIRONMENTS.PROD,
@@ -98,6 +103,11 @@ async function getNewAccessToken(accountId, personalAccessKey, expiresAt, env) {
   return accessToken;
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function accessTokenForPersonalAccessKey(accountId) {
   const { auth, personalAccessKey, env } = getAccountConfig(accountId);
   const authTokenInfo = auth && auth.tokenInfo;
@@ -121,6 +131,10 @@ async function accessTokenForPersonalAccessKey(accountId) {
 }
 
 /**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ *
  * Adds a account to the config using authType: personalAccessKey
  *
  * @param {object} configData Data containing personalAccessKey and name properties

--- a/sandboxes.js
+++ b/sandboxes.js
@@ -10,6 +10,11 @@ const {
   fetchTypes: _fetchTypes,
 } = require('./api/sandboxes-sync');
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function createSandbox(accountId, name, type) {
   let resp;
 
@@ -25,6 +30,11 @@ async function createSandbox(accountId, name, type) {
   };
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function deleteSandbox(parentAccountId, sandboxAccountId) {
   let resp;
 
@@ -41,6 +51,11 @@ async function deleteSandbox(parentAccountId, sandboxAccountId) {
   };
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function getSandboxUsageLimits(parentAccountId, sandboxAccountId) {
   let resp;
 
@@ -53,6 +68,11 @@ async function getSandboxUsageLimits(parentAccountId, sandboxAccountId) {
   return resp && resp.usage;
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function initiateSync(fromHubId, toHubId, tasks, sandboxHubId) {
   let resp;
 
@@ -65,6 +85,11 @@ async function initiateSync(fromHubId, toHubId, tasks, sandboxHubId) {
   return resp;
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function fetchTaskStatus(accountId, taskId) {
   let resp;
 
@@ -77,6 +102,11 @@ async function fetchTaskStatus(accountId, taskId) {
   return resp;
 }
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 async function fetchTypes(accountId, toHubId) {
   let resp;
 

--- a/schema.js
+++ b/schema.js
@@ -7,6 +7,11 @@ const { fetchSchemas, fetchSchema } = require('./api/schema');
 const chalk = require('chalk');
 const { table, getBorderCharacters } = require('table');
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const logSchemas = schemas => {
   const data = schemas
     .map(r => [r.labels.singular, r.name, r.objectTypeId || ''])
@@ -25,6 +30,11 @@ const logSchemas = schemas => {
   logger.log(data.length ? table(data, tableConfig) : 'No Schemas were found');
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const cleanSchema = schema => {
   const parsedSchema = {};
   parsedSchema.name = schema.name;
@@ -47,12 +57,22 @@ const cleanSchema = schema => {
   return parsedSchema;
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const getResolvedPath = (dest, name) => {
   if (name) return path.resolve(getCwd(), dest || '', `${name}.json`);
 
   return path.resolve(getCwd(), dest || '');
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const writeSchemaToDisk = (schema, dest) =>
   fs.outputFileSync(
     getResolvedPath(dest, schema.name),
@@ -61,11 +81,21 @@ const writeSchemaToDisk = (schema, dest) =>
     })
   );
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const listSchemas = async accountId => {
   const response = await fetchSchemas(accountId);
   logSchemas(response.results);
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const downloadSchemas = async (accountId, dest) => {
   const response = await fetchSchemas(accountId);
   logSchemas(response.results);
@@ -77,6 +107,11 @@ const downloadSchemas = async (accountId, dest) => {
   return;
 };
 
+/**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
+ */
 const downloadSchema = async (accountId, schemaObjectType, dest) => {
   const response = await fetchSchema(accountId, schemaObjectType);
   writeSchemaToDisk(response, dest);

--- a/validate.js
+++ b/validate.js
@@ -6,6 +6,9 @@ const { logger } = require('./logger');
 const { getExt } = require('./path');
 
 /**
+ * @deprecated
+ * Use the corresponding export from local-dev-lib
+ * https://github.com/HubSpot/hubspot-local-dev-lib
  * @async
  * @param {number} accountId
  * @param {string} filepath
@@ -53,6 +56,9 @@ function printHublValidationError(err) {
   logger[method]('[%d, %d]: %s', lineno, startPosition, message);
 }
 
+/**
+ * @deprecated
+ */
 function printHublValidationResult({ file, validation }) {
   let count = 0;
   const errors = getErrorsFromHublValidationObject(validation);


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Adding deprecation annotations to exported utils that the HubSpot CLI is now importing from the new local-dev-lib library. This should help to prevent new changes from being made in this library for exports that aren't being used anymore.

## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
<!--IMPORTANT: When making any changes to cli-lib, check to see if the files you've changed have already been ported to hubspot-local-dev-lib. If they have, please make a PR to hubspot-local-dev-lib with your changes. New files should also be ported to hubspot-local-dev-lib if all of their dependancies have already been ported -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
