### PR TITLE
Swap index routes

### DIFF
--- a/api/designManager.js
+++ b/api/designManager.js
@@ -49,9 +49,9 @@ async function fetchModulesByPath(accountId, path) {
   });
 }
 
-async function fetchModulesPathStartsWith(accountId, path) {
+async function fetchPreviewModules(accountId, token) {
   return http.get(accountId, {
-    uri: `${DESIGN_MANAGER_API_PATH}/modules?portalId=${accountId}&path__startswith=${path}`,
+    uri: `${DESIGN_MANAGER_API_PATH}/modules/local-preview?portalId=${accountId}&previewToken=${token}`,
   });
 }
 
@@ -61,9 +61,9 @@ async function fetchTemplatesByPath(accountId, path) {
   });
 }
 
-async function fetchTemplatesPathStartsWith(accountId, path) {
+async function fetchPreviewTemplates(accountId, token) {
   return http.get(accountId, {
-    uri: `${DESIGN_MANAGER_API_PATH}/templates?portalId=${accountId}&path__startswith=${path}`,
+    uri: `${DESIGN_MANAGER_API_PATH}/templates/local-preview?portalId=${accountId}&previewToken=${token}`,
   });
 }
 
@@ -73,7 +73,7 @@ module.exports = {
   fetchRawAssetByPath,
   fetchThemes,
   fetchModulesByPath,
-  fetchModulesPathStartsWith,
+  fetchPreviewModules,
   fetchTemplatesByPath,
-  fetchTemplatesPathStartsWith,
+  fetchPreviewTemplates,
 };

--- a/lib/preview/routes/index.js
+++ b/lib/preview/routes/index.js
@@ -3,8 +3,8 @@ const {
   trackPreviewEvent,
 } = require('../previewUtils');
 const {
-  fetchTemplatesPathStartsWith,
-  fetchModulesPathStartsWith
+  fetchPreviewTemplates,
+  fetchPreviewModules
 } = require('../../../api/designManager');
 const { parse: pathParse } = require('path');
 
@@ -35,11 +35,11 @@ const buildIndexHtml = async (sessionInfo) => {
         <div style="width:100%;display:flex;flex-direction:row;justify-content:space-evenly">
           <div>
             <h1>Modules</h1>
-            ${ modulesHtml ? modulesHtml : `<p>No modules found in ${fakeDest}</p>` }
+            ${ modulesHtml ? modulesHtml : `<p>No modules found in ${dest}</p>` }
           </div>
           <div>
             <h1>Templates</h1>
-            ${ templatesHtml ? templatesHtml : `<p>No templates found in ${fakeDest}</p>` }
+            ${ templatesHtml ? templatesHtml : `<p>No templates found in ${dest}</p>` }
           </div>
         </div>
       </body>
@@ -62,9 +62,9 @@ const listify = (objects, hrefBuilder, labelBuilder) => {
 }
 
 const getModulesForDisplayToUser = async (sessionInfo) => {
-  const { portalId, dest } = sessionInfo;
+  const { portalId, sessionToken } = sessionInfo;
   try {
-    const res = await fetchModulesPathStartsWith(portalId, dest);
+    const res = await fetchPreviewModules(portalId, sessionToken);
     const modulePaths = res
       .objects
       .map(moduleObj => moduleObj.path);
@@ -78,9 +78,9 @@ const getModulesForDisplayToUser = async (sessionInfo) => {
 }
 
 const getTemplatesForDisplayToUser = async (sessionInfo) => {
-  const { portalId, dest } = sessionInfo;
+  const { portalId, sessionToken } = sessionInfo;
   try {
-    const res = await fetchTemplatesPathStartsWith(portalId, dest);
+    const res = await fetchPreviewTemplates(portalId, sessionToken);
     const templatePaths = res
       .objects
       .filter(templateObj => templateObj.filename.endsWith('html'))

--- a/lib/preview/routes/proxyPageRouteHandler.js
+++ b/lib/preview/routes/proxyPageRouteHandler.js
@@ -41,7 +41,7 @@ const buildProxyPageRouteHandler = (sessionInfo) => {
         portalId,
         hublet,
         contentId,
-        urlToProxy,
+        `${urlToProxy}?localPreviewToken=${sessionInfo.sessionToken}&hsCacheBuster=${Date.now()}`,
       );
     } catch (e) {
       next(e);


### PR DESCRIPTION
@HubSpot/cms-developer-tooling 

Swaps fetches on the index route to use new local preview endpoints instead of the ones that we can't use anymore!