### PR TITLE
Move to cos-rendering endpoint

### DIFF
--- a/api/preview.js
+++ b/api/preview.js
@@ -1,9 +1,43 @@
 const { get } = require('../http');
 const http = require('http');
 const https = require('https');
-const { getAccountId } = require('../lib/config');
 
 const CONTENT_API_PATH = `/content/api/v4/contents`;
+const COS_RENDER_PATH = `/cos-rendering/v1/public`;
+
+async function fetchPreviewRender(url, sessionInfo) {
+  const { portalId, env, sessionToken } = sessionInfo;
+
+  const urlObject = new URL(url);
+
+  const proxiedQueryParams = {};
+
+  // Convert searchParams to object param format hsGet/request expects
+  for (const queryKey of urlObject.searchParams.keys()) {
+    const values = urlObject.searchParams.getAll(queryKey);
+
+    if (values.length > 1) {
+      proxiedQueryParams[queryKey] = values;
+    } else {
+      proxiedQueryParams[queryKey] = values[0];
+    }
+  }
+
+  return get(portalId, {
+    baseUrl: `http://api.hubspot${env === 'qa' ? 'qa' : ''}.com`,
+    uri: COS_RENDER_PATH,
+    query: {
+      ...proxiedQueryParams,
+      portalId,
+      localSessionToken: sessionToken,
+      hsCacheBuster: Date.now(),
+      hsDebugOverridePublicHost: urlObject.hostname,
+    },
+    headers: {
+      Accept: "text/html"
+    },
+  });
+}
 
 async function fetchPreviewInfo(accountId, contentId) {
   try {
@@ -21,35 +55,6 @@ async function fetchPreviewInfo(accountId, contentId) {
     throw err;
   }
 }
-
-const requestContentPreview = async (url, portalId) => {
-  const urlObject = new URL(url);
-
-  const proxiedQueryParams = {};
-
-  // Convert searchParams to object param format hsGet/request expects
-  for (const queryKey of urlObject.searchParams.keys()) {
-    const values = urlObject.searchParams.getAll(queryKey);
-
-    if (values.length > 1) {
-      proxiedQueryParams[queryKey] = values;
-    } else {
-      proxiedQueryParams[queryKey] = values[0];
-    }
-  }
-
-  const accountId = getAccountId(portalId);
-
-  const response = await get(accountId, {
-    baseUrl: urlObject.origin,
-    uri: urlObject.pathname,
-    query: proxiedQueryParams,
-    json: false,
-    resolveWithFullResponse: true,
-  });
-
-  return response;
-};
 
 const requestPage = (url, redirects = 0, originalUrl = undefined) => {
   if (redirects > 5) {
@@ -98,64 +103,7 @@ const requestPage = (url, redirects = 0, originalUrl = undefined) => {
   });
 };
 
-const fetchContentMetadata = async (url, portalId) => {
-  let res;
-  if (url.includes('hs_preview')) {
-    res = await requestContentPreview(url, portalId);
-  } else {
-    res = await requestPage(url);
-  }
-
-  const portalIdHeader = res.headers['x-hs-hub-id'];
-  const contentId = res.headers['x-hs-content-id'];
-
-  if (Array.isArray(portalIdHeader) || Array.isArray(contentId)) {
-    throw new Error(
-      `There were multiple hub ID or content ID headers in the HEAD request to ${url}`
-    );
-  } else {
-    const portalIdFromResponse = parseInt(portalIdHeader, 10);
-    const pageAccount = await getAccountId(portalIdFromResponse);
-
-    if (!pageAccount) {
-      throw new Error(
-        `No CLI auth for portal ${portalIdFromResponse} found, please run \`hs auth\``
-      );
-    }
-
-    if (res.statusCode !== 200) {
-      throw new Error(
-        `${res.statusCode} ${
-          res.statusMessage
-        } - Unable to obtain HEAD information from ${url}. ${
-          res.statusCode === 429 && res.headers['retry-after']
-            ? `Retry after ${res.headers['retry-after']} seconds.`
-            : ''
-        }`
-      );
-    } else if (!portalId || !contentId) {
-      throw new Error(
-        `Missing hub ID or content ID headers on HEAD request to ${url}`
-      );
-    } else if (isNaN(portalId)) {
-      throw new Error(
-        `Hub ID from the HEAD request is not a number: '${portalId}' (${url})`
-      );
-    }
-
-    // TODO, the hubs-hublets/hublets/find/<portalId> API is internal auth only.🤔...
-    // Prior implementation of fetchHubletForPortalId that would work execept for an internal auth issue:
-    // https://git.hubteam.com/HubSpot/cms-js-platform/blob/ef6e8029df6c09fe30d65a80073606f41ca324a6/cms-dev-server/src/proxyPage/fetchHubletForPortalId.ts
-    //
-    // const hublet = await fetchHubletForPortalId(portalId);
-
-    const hublet = 'na1';
-
-    return { portalId, contentId, hublet };
-  }
-};
-
 module.exports = {
+  fetchPreviewRender,
   fetchPreviewInfo,
-  fetchContentMetadata,
 };

--- a/api/preview.js
+++ b/api/preview.js
@@ -1,6 +1,5 @@
 const { get } = require('../http');
 
-const CONTENT_API_PATH = `/content/api/v4/contents`;
 const COS_RENDER_PATH = `/cos-rendering/v1/public`;
 
 async function fetchPreviewRender(url, sessionInfo) {
@@ -37,24 +36,6 @@ async function fetchPreviewRender(url, sessionInfo) {
   });
 }
 
-async function fetchPreviewInfo(accountId, contentId) {
-  try {
-    const content = await get(accountId, {
-      uri: `${CONTENT_API_PATH}/${contentId}`,
-      query: { portalId: accountId },
-      json: true,
-    });
-
-    return {
-      previewDomain: content.previewDomain ?? content.resolvedDomain,
-      previewKey: content.previewKey,
-    };
-  } catch (err) {
-    throw err;
-  }
-}
-
 module.exports = {
   fetchPreviewRender,
-  fetchPreviewInfo,
 };

--- a/api/preview.js
+++ b/api/preview.js
@@ -1,6 +1,4 @@
 const { get } = require('../http');
-const http = require('http');
-const https = require('https');
 
 const CONTENT_API_PATH = `/content/api/v4/contents`;
 const COS_RENDER_PATH = `/cos-rendering/v1/public`;
@@ -55,53 +53,6 @@ async function fetchPreviewInfo(accountId, contentId) {
     throw err;
   }
 }
-
-const requestPage = (url, redirects = 0, originalUrl = undefined) => {
-  if (redirects > 5) {
-    throw new Error(
-      `Hit too many redirects to HEAD requests for ${originalUrl}`
-    );
-  }
-
-  return new Promise((resolve, reject) => {
-    const protocolAPI = url.startsWith('https://') ? https : http;
-    protocolAPI
-      .request(
-        url,
-        {
-          method: 'HEAD',
-          headers: {
-            // Keep this user agent, so we don't get 403s from the request
-            ['User-Agent']: 'cms-dev-server',
-          },
-        },
-        async res => {
-          // Use a lib to better follow various redirects?
-          if (
-            res.statusCode >= 300 &&
-            res.statusCode < 400 &&
-            res.headers.location
-          ) {
-            console.log(`Redirecting to ${res.headers.location} (from ${url})`);
-            return resolve(
-              requestPage(
-                res.headers.location,
-                redirects + 1,
-                originalUrl ?? url
-              )
-            );
-          }
-
-          return resolve(res);
-        }
-      )
-      .on('error', err => {
-        console.error(err);
-        reject(err);
-      })
-      .end();
-  });
-};
 
 module.exports = {
   fetchPreviewRender,

--- a/api/preview.js
+++ b/api/preview.js
@@ -22,7 +22,7 @@ async function fetchPreviewRender(url, sessionInfo) {
 
   return get(portalId, {
     baseUrl: `http://api.hubspot${env === 'qa' ? 'qa' : ''}.com`,
-    uri: COS_RENDER_PATH,
+    uri: `${COS_RENDER_PATH}${urlObject.pathname}`,
     query: {
       ...proxiedQueryParams,
       portalId,

--- a/lib/preview/proxyPage.js
+++ b/lib/preview/proxyPage.js
@@ -1,87 +1,26 @@
-const http = require('../../http');
-const { fetchPreviewInfo } = require('../../api/preview');
-const { addRefreshScript, memoize } = require('./previewUtils');
-
-const cachedFetchPreviewInfo = memoize(fetchPreviewInfo);
+const { addRefreshScript } = require('./previewUtils');
+const { fetchPreviewRender } = require('../../api/preview');
 
 const proxyPage = async (
   res,
-  portalId,
-  hublet,
-  contentId,
   urlToProxy,
+  sessionInfo
 ) => {
   try {
-    const previewInfo = await cachedFetchPreviewInfo(portalId, contentId);
-
-    const { previewKey } = previewInfo;
-
-    const pageHtml = await makeProxyPreviewRequest(
-      portalId,
-      urlToProxy,
-      previewKey,
-      contentId
-    )
+    const pageHtml = await fetchPreviewRender(urlToProxy, sessionInfo);
 
     const embeddedHtml = addRefreshScript(pageHtml);
     res.status(200).set({ 'Content-Type': 'text/html' }).end(embeddedHtml);
   } catch (error) {
+    const { portalId } = sessionInfo;
     // TODO change error.stack to error.message before we publish
-    response
+    res
       .status(500)
       .end(
-        `Failed proxy render of page id = ${contentId} hub id = ${portalId}\n\n${error.stack}`
+        `Failed proxy render of page ${urlToProxy} hub id = ${portalId}\n\n${error.stack}`
       );
     return;
   }
-}
-
-const makeProxyPreviewRequest = async (
-  portalId,
-  urlToProxy,
-  previewKey,
-  contentId
-) => {
-  const url = new URL(urlToProxy);
-
-  let proxiedQueryParams = {};
-
-  // Convert searchParams to object param format hsGet/request expects
-  for (const queryKey of url.searchParams.keys()) {
-    const values = url.searchParams.getAll(queryKey);
-
-    if (values.length > 1) {
-      proxiedQueryParams[queryKey] = values;
-    } else {
-      proxiedQueryParams[queryKey] = values[0];
-    }
-  }
-
-  proxiedQueryParams = {
-    ...proxiedQueryParams,
-    hs_preview: `${previewKey}-${contentId}`,
-  };
-
-  const result = http.get(portalId, {
-    baseUrl: url.origin,
-    uri: url.pathname,
-    query: proxiedQueryParams,
-    json: false,
-    useQuerystring: true,
-  });
-
-  return result.catch(error => {
-    if (
-      error.statusCode >= 400 &&
-      error.statusCode < 500 &&
-      !!error.response.body
-    ) {
-      return error.response.body;
-    } else {
-      throw error;
-    }
-  });
-
 }
 
 module.exports = {

--- a/lib/preview/routes/proxyPageRouteHandler.js
+++ b/lib/preview/routes/proxyPageRouteHandler.js
@@ -1,13 +1,9 @@
-const { fetchContentMetadata } = require('../../../api/preview');
 const { proxyPage } = require('../proxyPage.js');
 const {
   getSubDomainFromValidLocalDomain,
   VALID_PROXY_DOMAIN_SUFFIXES,
-  memoize,
   trackPreviewEvent
 } = require('../previewUtils.js');
-
-const cachedFetchContentMetadata = memoize(fetchContentMetadata);
 
 const buildProxyPageRouteHandler = (sessionInfo) => {
   return async (request, response, next) => {
@@ -31,17 +27,10 @@ const buildProxyPageRouteHandler = (sessionInfo) => {
     const urlToProxy = `http://${domainToProxy}${request.originalUrl}`;
 
     try {
-      const { portalId, contentId, hublet } = await cachedFetchContentMetadata(
-        urlToProxy,
-        sessionInfo.portalId
-      );
-
       await proxyPage(
         response,
-        portalId,
-        hublet,
-        contentId,
-        `${urlToProxy}?localPreviewToken=${sessionInfo.sessionToken}&hsCacheBuster=${Date.now()}`,
+        urlToProxy,
+        sessionInfo,
       );
     } catch (e) {
       next(e);

--- a/lib/preview/routes/proxyPathPageRouteHandler.js.js
+++ b/lib/preview/routes/proxyPathPageRouteHandler.js.js
@@ -1,4 +1,3 @@
-const { fetchContentMetadata } = require('../../../api/preview');
 const { proxyPage } = require('../proxyPage');
 const { trackPreviewEvent } = require('../previewUtils');
 
@@ -28,17 +27,10 @@ const buildProxyRouteHandler = (sessionInfo) => {
     }
     trackPreviewEvent('proxy-path-route');
     try {
-      const { portalId, contentId, hublet } = await fetchContentMetadata(
-        proxyPageUrl.href,
-        sessionInfo.portalId
-      )
-
       await proxyPage(
         res,
-        portalId,
-        hublet,
-        contentId,
-        proxyPageUrl.href
+        proxyPageUrl.href,
+        sessionInfo
       );
     } catch (e) {
       const message = `Failed to fetch proxy page for ${proxyPageUrl.href}`;


### PR DESCRIPTION
Moves to logic for page previewing to cos-rendering endpoint that Niket added preview support to. Much of the old approach can be axed! 