### PR TITLE
Adding logic for React modules in create command

### DIFF
--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -23,6 +23,7 @@ en:
             errors:
               pathExists: "The {{ path }} path already exists"
               failedToWriteMeta: "There was an problem writing the module's meta data at {{ path }}"
+              fileReadFailure: "Failed to read file at {{ path }}"
       project:
         subcommands:
           watch:

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -24,6 +24,7 @@ en:
               pathExists: "The {{ path }} path already exists"
               failedToWriteMeta: "There was an problem writing the module's meta data at {{ path }}"
               fileReadFailure: "Failed to read file at {{ path }}"
+              failedToWrite: "failed to write to file at {{ path }}"
       project:
         subcommands:
           watch:

--- a/lang/en.lyaml
+++ b/lang/en.lyaml
@@ -22,6 +22,7 @@ en:
             creatingPath: "Creating {{ path }}"
             errors:
               pathExists: "The {{ path }} path already exists"
+              failedToWriteMeta: "There was an problem writing the module's meta data at {{ path }}"
       project:
         subcommands:
           watch:

--- a/modules.js
+++ b/modules.js
@@ -272,7 +272,7 @@ const createModule = async (
     `
         : '';
 
-      fs.readFile(`${destPath}/index.tsx`, 'utf8', function(err, data) {
+      fs.readFile(`${destPath}/index.tsx`, 'utf8', (err, data) => {
         if (err) {
           logger.error(
             i18n(`${i18nKey}.errors.fileReadFailure`, {
@@ -286,7 +286,7 @@ const createModule = async (
           .replace(/\/\* import global styles \*\//g, globalImportString)
           .replace(/\/\* Default config \*\//g, defaultconfigString);
 
-        fs.writeFile(`${destPath}/index.tsx`, result, 'utf8', (err) => {
+        fs.writeFile(`${destPath}/index.tsx`, result, 'utf8', err => {
           if (err) return console.log(err);
         });
 

--- a/modules.js
+++ b/modules.js
@@ -335,7 +335,9 @@ const createModule = async (
   };
 
   // Download gitHub contents to the dest directory
-  const sampleAssetPath = !isReactModule ? 'Sample.module' : 'SampleJSR';
+  const sampleAssetPath = !isReactModule
+    ? 'Sample.module'
+    : 'SampleReactModule';
 
   await downloadGitHubRepoContents(
     'HubSpot/cms-sample-assets',

--- a/modules.js
+++ b/modules.js
@@ -183,6 +183,7 @@ const createModule = async (
   }
 ) => {
   const i18nKey = 'cli.commands.create.subcommands.module';
+
   const writeModuleMeta = ({ contentTypes, moduleLabel, global }, dest) => {
     const metaData = {
       label: moduleLabel,
@@ -252,6 +253,86 @@ const createModule = async (
   );
 };
 
+const createReactModule = async (
+  moduleDefinition,
+  name,
+  dest,
+  getInternalVersion,
+  options = {
+    allowExistingDir: false,
+  }
+) => {
+  // Params shape
+  /*
+    {
+      moduleLabel: 'duh',
+      reactType: true,
+      contentTypes: [ 'PAGE' ],
+      global: false
+    }
+    test
+    /Users/tscales/hubspot-repos/Growth
+    undefined
+  */
+
+  console.log(moduleDefinition.contentTypes);
+
+  // TODO: Refactor to abstract from both create commands
+  const i18nKey = 'cli.commands.create.subcommands.module';
+  const destPath = path.join(dest, `${name}React`);
+  if (!options.allowExistingDir && fs.existsSync(destPath)) {
+    logger.error(
+      i18n(`${i18nKey}.errors.pathExists`, {
+        path: destPath,
+      })
+    );
+    return;
+  } else {
+    logger.log(
+      i18n(`${i18nKey}.creatingPath`, {
+        path: destPath,
+      })
+    );
+    fs.ensureDirSync(destPath);
+  }
+
+  logger.log(
+    i18n(`${i18nKey}.creatingModule`, {
+      path: destPath,
+    })
+  );
+
+  // meta pattern for react modules
+  const contentTypeArrayToString =
+    `[` +
+    moduleDefinition.contentTypes.map(type => {
+      return '"' + type + '"';
+    }) +
+    `]`;
+
+  const reactMeta =
+    `export const meta = {
+  label: "${moduleDefinition.moduleLabel}",
+  host_template_types:` +
+    contentTypeArrayToString +
+    `,
+  global: ${moduleDefinition.global}
+}`;
+
+  await downloadGitHubRepoContents(
+    'HubSpot/cms-sample-assets',
+    'modules/SampleJSR',
+    destPath,
+    { ref: 'ts/152-JSR-module-create' }
+  );
+
+  fs.appendFile(`${destPath}/index.tsx`, reactMeta, err => {
+    if (err) {
+      console.log(err);
+    }
+  });
+};
+
 module.exports = {
   isModuleFolder,
   isModuleFolderChild,
@@ -260,4 +341,5 @@ module.exports = {
   isModuleHTMLFile,
   isModuleCSSFile,
   createModule,
+  createReactModule,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cli-lib",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Library for creating scripts for working with HubSpot",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
## Description and Context

With the advent of React modules being used in the CMS at HubSpot -- there is a need to include the ability to quickly scaffold a React module from the `hs create module` command.

This PR adds logic so that a dev can call `hs create module` and within the creation prompt, a new question has been added for creating a React type module. If this is selected, then the command will pull from the React sample asset in the `cms-sample-assets` repo. 

There is also some refining of the code after a React module has been downloaded to add the meta data information to the `index.tsx` file -- Additionally, if the `internal` flag is passed, there are some regex replacements that happen to include some bits of code required by our internal team, as well as some additional files downloaded from the sample asset repo that pertain more to them.

## Screenshots
Loom of the command: https://www.loom.com/share/ea1e16ea73d946d685af94223a522bec?sid=8b5a1ee8-ceaf-49f6-b75f-1438c0e2d647

## TODO
- [x] Port these changes to [hubspot-local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib) -- [see PR here](https://github.com/HubSpot/hubspot-local-dev-lib/pull/78)