### PR TITLE
Add ENVLESS_API_OVERRIDE for api domain modification

### DIFF
--- a/lib/urls.js
+++ b/lib/urls.js
@@ -17,13 +17,27 @@ const getHubSpotWebsiteOrigin = env => {
   return `https://app.hubspot${getEnvUrlString(env)}.com`;
 };
 
+const getHubApiDomainOverride = env => {
+  let domainOverride = process.env.HUBAPI_DOMAIN_OVERRIDE;
+  if (domainOverride && typeof domainOverride === 'string') {
+    return domainOverride;
+  }
+
+  let envlessApiOverride = process.env.ENVLESS_API_OVERRIDE;
+  if (envlessApiOverride && typeof envlessApiOverride === 'string') {
+    return `${envlessApiOverride}${getEnvUrlString(env)}`;
+  }
+
+  return null;
+};
+
 /**
  * @deprecated
  * Use the corresponding export from local-dev-lib
  * https://github.com/HubSpot/hubspot-local-dev-lib
  */
 const getHubSpotApiOrigin = (env, useLocalHost) => {
-  let domain = process.env.HUBAPI_DOMAIN_OVERRIDE;
+  let domain = getHubApiDomainOverride(env);
 
   if (!domain || typeof domain !== 'string') {
     domain = `${useLocalHost ? 'local' : 'api'}.hubapi${getEnvUrlString(env)}`;


### PR DESCRIPTION
## Description and Context

Adds an environment variable ENVLESS_API_OVERRIDE which overrides the beginning of the hubapi domain. That is, the environment of the account will be appended to this override value. This allows us to set the domain override in our systems that works regardless of the account environment.

This variable should likely replace HUBAPI_DOMAIN_OVERRIDE in the future. HUBAPI_DOMAIN_OVERRIDE allows you to mistakenly mismatch environments between the accounts and the actual domain being hit.