### PR TITLE
Make HUBAPI_DOMAIN_OVERRIDE environment independent

### DIFF
--- a/lib/__tests__/urls.js
+++ b/lib/__tests__/urls.js
@@ -1,0 +1,61 @@
+const { getHubSpotApiOrigin } = require('../urls');
+
+describe('urls', () => {
+  describe('getHubSpotApiOrigin()', () => {
+    // Suggestion taken from stack overflow https://stackoverflow.com/a/48042799
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+      process.env = { ...OLD_ENV };
+    });
+
+    afterAll(() => {
+      process.env = OLD_ENV;
+    });
+
+    it('gets qa url', () => {
+      const url = getHubSpotApiOrigin('qa', false);
+
+      expect(url).toBe('https://api.hubapiqa.com');
+    });
+
+    it('gets prod url', () => {
+      const url = getHubSpotApiOrigin('prod', false);
+
+      expect(url).toBe('https://api.hubapi.com');
+    });
+
+    it('gets qa local url', () => {
+      const url = getHubSpotApiOrigin('qa', true);
+
+      expect(url).toBe('https://local.hubapiqa.com');
+    });
+
+    it('gets prod local url', () => {
+      const url = getHubSpotApiOrigin('prod', true);
+
+      expect(url).toBe('https://local.hubapi.com');
+    });
+
+    it('gets qa override url', () => {
+      process.env.HUBAPI_DOMAIN_OVERRIDE = 'api.hubspot';
+      const url = getHubSpotApiOrigin('qa', false);
+
+      expect(url).toBe('https://api.hubspotqa.com');
+    });
+
+    it('gets prod override url', () => {
+      process.env.HUBAPI_DOMAIN_OVERRIDE = 'api.hubspot';
+      const url = getHubSpotApiOrigin('prod', false);
+
+      expect(url).toBe('https://api.hubspot.com');
+    });
+
+    it('ignores local argument when using override', () => {
+      process.env.HUBAPI_DOMAIN_OVERRIDE = 'api.hubspot';
+      const url = getHubSpotApiOrigin('qa', true);
+
+      expect(url).toBe('https://api.hubspotqa.com');
+    });
+  });
+});

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -23,8 +23,11 @@ const getHubSpotWebsiteOrigin = env => {
  * https://github.com/HubSpot/hubspot-local-dev-lib
  */
 const getHubSpotApiOrigin = (env, useLocalHost) => {
-  let domain = process.env.HUBAPI_DOMAIN_OVERRIDE;
-
+  let domain;
+  const domainOverride = process.env.HUBAPI_DOMAIN_OVERRIDE;
+  if (domainOverride && typeof domainOverride === 'string') {
+    domain = `${domainOverride}${getEnvUrlString(env)}`;
+  }
   if (!domain || typeof domain !== 'string') {
     domain = `${useLocalHost ? 'local' : 'api'}.hubapi${getEnvUrlString(env)}`;
   }


### PR DESCRIPTION
## Description and Context

Reworks getHubSpotApiOrigin to append the environment suffix to a passed environment variable HUBAPI_DOMAIN_OVERRIDE. This makes the override independent to environments. You can no longer mistakenly pass a domain override which conflicts with the environment of the account. It also lets you "set and forget" the HUBAPI_DOMAIN_OVERRIDE variable in your shell settings, say in .zshrc, and it will work as expected in all cases.

Adds tests for urls.js to test the normal cases, as well as tests for the override behavior.